### PR TITLE
Fix unwanted double rotation

### DIFF
--- a/addons/area_of_sight_2d/area_of_sight_2d.gd
+++ b/addons/area_of_sight_2d/area_of_sight_2d.gd
@@ -175,7 +175,7 @@ func _set_points() -> void:
 		
 	for i in range(rays_amount + it):
 		var point : Vector2 = _ray_to(
-			to_global(Vector2(radius, 0).rotated(rotation - _semiangle + i * _angle_step))
+			to_global(Vector2(radius, 0).rotated(0 - _semiangle + i * _angle_step))
 		)
 		result.append(to_local(point))
 		


### PR DESCRIPTION
Currently area of sight node rotating itself + additional rotation of rays based on node rotation, that creates unwanted additional rotation that not equal in behavior as other nodes rotation, basically is cause rotation + rotation, so I removed unwanted rotation to better correspond behavior as other nodes 2D

Collisions and example scene still working, tested in 4.3 release